### PR TITLE
Улучшить правила парсинга

### DIFF
--- a/src/__tests__/assert-parser.test.ts
+++ b/src/__tests__/assert-parser.test.ts
@@ -37,4 +37,10 @@ describe('assert-parser', () => {
       { raw: 'http://sit-amet.com?retpath=https://consectetur.com', value: undefined },
     ]);
   });
+
+  test('не должен возвращать ссылки без протокола', () => {
+    const result = parse('Lorem.ipsum.dolor sit amet consectetur adipisicing elit.');
+
+    expect(result.meta.urls).toHaveLength(0);
+  });
 });

--- a/src/__tests__/assert-parser.test.ts
+++ b/src/__tests__/assert-parser.test.ts
@@ -27,6 +27,12 @@ describe('assert-parser', () => {
     ]);
   });
 
+  test('не должен возвращать отсылки внутри выделений', () => {
+    const result = parse('`Lorem $ipsum-com` dolor');
+
+    expect(result.meta.references).toHaveLength(0);
+  });
+
   test('должен возвращать все ссылки', () => {
     const result = parse(
       'Lorem https://ipsum.com?dolor http://sit-amet.com?retpath=https://consectetur.com adipisicing elit.',

--- a/src/__tests__/assert-parser.test.ts
+++ b/src/__tests__/assert-parser.test.ts
@@ -43,4 +43,10 @@ describe('assert-parser', () => {
 
     expect(result.meta.urls).toHaveLength(0);
   });
+
+  test('не должен возвращать ссылки внутри выделений', () => {
+    const result = parse('`Lorem https://ipsum.com` dolor');
+
+    expect(result.meta.urls).toHaveLength(0);
+  });
 });

--- a/src/assert-parser.ts
+++ b/src/assert-parser.ts
@@ -5,13 +5,15 @@ export interface ParsedValue {
   value: string | undefined;
 }
 
+export interface ParseMeta {
+  highlights: ParsedValue[];
+  references: ParsedValue[];
+  urls: ParsedValue[];
+}
+
 export interface ParseResult {
   assert: string;
-  meta: {
-    highlights: ParsedValue[];
-    references: ParsedValue[];
-    urls: ParsedValue[];
-  };
+  meta: ParseMeta;
 }
 
 /**

--- a/src/assert-parser.ts
+++ b/src/assert-parser.ts
@@ -25,15 +25,26 @@ export function parse(assert: string) {
     meta: { highlights: [], references: [], urls: [] },
   };
 
-  extract(assert, rules.highlight, result.meta.highlights);
-  extract(assert, rules.reference, result.meta.references);
-  extract(assert, rules.url, result.meta.urls);
+  pipe(
+    extract(rules.highlight, result.meta.highlights),
+    extract(rules.reference, result.meta.references),
+    extract(rules.url, result.meta.urls),
+  )(assert);
 
   return result;
 }
 
-function extract(value: string, regex: RegExp, values: ParsedValue[]) {
-  for (const match of value.matchAll(regex)) {
-    values.push({ raw: match.at(0) as string, value: match.at(1) });
-  }
+function extract(regex: RegExp, values: ParsedValue[]) {
+  return (value: string) => {
+    for (const match of value.matchAll(regex)) {
+      values.push({ raw: match.at(0) as string, value: match.at(1) });
+      value = value.replace(match.at(0) as string, '');
+    }
+
+    return value;
+  };
+}
+
+function pipe<T>(fn: (a: T) => T, ...fns: Array<(a: T) => T>) {
+  return fns.reduce((prevFn, nextFn) => (value) => nextFn(prevFn(value)), fn);
 }

--- a/src/assert-rules.ts
+++ b/src/assert-rules.ts
@@ -3,5 +3,5 @@ import urlRegex from 'url-regex-safe';
 export const rules = {
   highlight: /`((?:\\`|[^`])+)`/gi,
   reference: /\$([a-zA-Z0-9\._-]+)/gi,
-  url: urlRegex({ localhost: false, ipv4: false, ipv6: false }),
+  url: urlRegex({ localhost: false, ipv4: false, ipv6: false, strict: true }),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { parse, type ParsedValue, type ParseResult } from './assert-parser';
+export { parse, type ParsedValue, type ParseResult, type ParseMeta } from './assert-parser';


### PR DESCRIPTION
## Что сделал

1. Исправил парсинг ссылок без протокола (раньше строка вида `hello.world` воспринималась как ссылка)
2. Исправил парсинг ссылок внутри хайлайтов (теперь внутри хайлайта ссылка не парится)